### PR TITLE
Update ExtractFromUrl method to ExtractFromURL with multiple return. Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+/data
+/gofreeling

--- a/nlp/crawler.go
+++ b/nlp/crawler.go
@@ -24,6 +24,10 @@ func NewDefaultCrawler() *Crawler {
 
 func (this *Crawler) Analyze(url string) *goose.Article {
 	g := goose.New()
-	article := g.ExtractFromUrl(url)
+	article, err := g.ExtractFromURL(url)
+	if ( err != nil ) {
+		// TODO Probably want to handle this error...
+		panic(err)
+	}
 	return article
 }


### PR DESCRIPTION
This pull request fixes go-freeling with current GoOse API.
